### PR TITLE
Fix a possible buffer overrun

### DIFF
--- a/tui.c
+++ b/tui.c
@@ -126,7 +126,6 @@ int tui_draw_big_char(int *big,
     return 0;
 }
 
-#define SIZE_KEY_SEQUENCES 15
 static char *key_sequences[SIZE_KEY_SEQUENCES];
 
 static int is_supported_key(char *sequence, int *key, int len)

--- a/tui.h
+++ b/tui.h
@@ -3,7 +3,16 @@
 
 #include <stdbool.h>
 
-enum keys { K_UNKNOWN, K_UP, K_DOWN, K_LEFT, K_RIGHT, K_ESC, K_ENTER, SIZE_KEY_SEQUENCES };
+enum keys {
+    K_UNKNOWN,
+    K_UP,
+    K_DOWN,
+    K_LEFT,
+    K_RIGHT,
+    K_ESC,
+    K_ENTER,
+    SIZE_KEY_SEQUENCES
+};
 
 int tui_read_key(int *key);
 int tui_save_term();

--- a/tui.h
+++ b/tui.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-enum keys { K_UNKNOWN, K_UP, K_DOWN, K_LEFT, K_RIGHT, K_ESC, K_ENTER };
+enum keys { K_UNKNOWN, K_UP, K_DOWN, K_LEFT, K_RIGHT, K_ESC, K_ENTER, SIZE_KEY_SEQUENCES };
 
 int tui_read_key(int *key);
 int tui_save_term();


### PR DESCRIPTION
In is_supported_key(), when user hit a key not in enum keys, strlen()
may run over an uninitialized pointer and cause buffer overrrun.